### PR TITLE
fix: nvim startup still notify fall back base mode in base mode

### DIFF
--- a/lua/flow/colors.lua
+++ b/lua/flow/colors.lua
@@ -82,6 +82,16 @@ function M.setup(opts)
     colors.sky_blue = default_palette.sky_blue.desaturate
     colors.cyan = default_palette.cyan.desaturate
     colors.green = default_palette.green.desaturate
+  elseif opts.mode == "base" then
+    colors.orange = default_palette.orange.base
+    colors.yellow = default_palette.yellow.base
+    colors.red = default_palette.red.base
+    colors.purple = default_palette.purple.base
+    colors.blue = default_palette.blue.base
+    colors.light_blue = default_palette.light_blue.base
+    colors.sky_blue = default_palette.sky_blue.base
+    colors.cyan = default_palette.cyan.base
+    colors.green = default_palette.green.base
   else
     vim.notify(
       "Invalid mode: '" .. opts.mode .. "'. Falling back to 'base' mode.",


### PR DESCRIPTION
Resolve the tips i don't like.
i use this config, but it still notify
``` lua
{
  "0xstepit/flow.nvim",
  opts = function()
    return {
      mode = "base",
    }
  end,
}
```
![PixPin_241016_235002](https://github.com/user-attachments/assets/499e7b90-fce1-44f5-aa3a-b960bf761f09)
