### PR TITLE
feat: Add custom config for saturation and light

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ return {
       colors = {
         mode = "default", -- "default" | "dark" | "light"
         fluo = "pink", -- "pink" | "cyan" | "yellow" | "orange" | "green"
+        custom = {
+          saturation = "", -- "" | string representing an integer between 0 and 100
+          light = "", -- "" | string representing an integer between 0 and 100
+        },
       },
       ui = {
         borders = "inverse", -- "theme" | "inverse" | "fluo" | "none"
@@ -144,7 +148,7 @@ Flow.nvim provides colorschemes also for the following tools:
 
 - [fzf](https://github.com/junegunn/fzf) at [fzf-flow.sh](./extra/eclipse/fzf-flow-pink.sh).
 
-- ghostty at [ghostty-flow.config](./extra/eclipse/ghostty-flow-pink.config).
+- [ghostty](https://github.com/ghostty-org/ghostty) at [ghostty-flow.config](./extra/eclipse/ghostty-flow-pink.config).
 
 To generate extra themes you can use the `Makefile`:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ return {
   "0xstepit/flow.nvim",
   lazy = false,
   priority = 1000,
-  tag = "v1.0.0",
+  tag = "v2.0.1",
     opts = {
       theme = {
         style = "dark", --  "dark" | "light"

--- a/extra/moon-eclipse/ghostty-flow-cyan.config
+++ b/extra/moon-eclipse/ghostty-flow-cyan.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#db7079
+palette = 9=#db7079
+# green
+palette = 2=#79db70
+palette = 10=#79db70
+# yellow
+palette = 3=#dbdb70
+palette = 11=#dbdb70
+# blue
+palette = 4=#70afdb
+palette = 12=#70afdb
+# purple
+palette = 5=#a670db
+palette = 13=#a670db
+# aqua
+palette = 6=#70dbc1
+palette = 14=#70dbc1
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #00e1ff
+selection-background = #00e1ff
+selection-foreground = #0d0d0d

--- a/extra/moon-eclipse/ghostty-flow-green.config
+++ b/extra/moon-eclipse/ghostty-flow-green.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#db7079
+palette = 9=#db7079
+# green
+palette = 2=#79db70
+palette = 10=#79db70
+# yellow
+palette = 3=#dbdb70
+palette = 11=#dbdb70
+# blue
+palette = 4=#70afdb
+palette = 12=#70afdb
+# purple
+palette = 5=#a670db
+palette = 13=#a670db
+# aqua
+palette = 6=#70dbc1
+palette = 14=#70dbc1
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #15ff00
+selection-background = #15ff00
+selection-foreground = #0d0d0d

--- a/extra/moon-eclipse/ghostty-flow-orange.config
+++ b/extra/moon-eclipse/ghostty-flow-orange.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#db7079
+palette = 9=#db7079
+# green
+palette = 2=#79db70
+palette = 10=#79db70
+# yellow
+palette = 3=#dbdb70
+palette = 11=#dbdb70
+# blue
+palette = 4=#70afdb
+palette = 12=#70afdb
+# purple
+palette = 5=#a670db
+palette = 13=#a670db
+# aqua
+palette = 6=#70dbc1
+palette = 14=#70dbc1
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #ff6a00
+selection-background = #ff6a00
+selection-foreground = #0d0d0d

--- a/extra/moon-eclipse/ghostty-flow-pink.config
+++ b/extra/moon-eclipse/ghostty-flow-pink.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#db7079
+palette = 9=#db7079
+# green
+palette = 2=#79db70
+palette = 10=#79db70
+# yellow
+palette = 3=#dbdb70
+palette = 11=#dbdb70
+# blue
+palette = 4=#70afdb
+palette = 12=#70afdb
+# purple
+palette = 5=#a670db
+palette = 13=#a670db
+# aqua
+palette = 6=#70dbc1
+palette = 14=#70dbc1
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #ff007b
+selection-background = #ff007b
+selection-foreground = #0d0d0d

--- a/extra/moon-eclipse/ghostty-flow-yellow.config
+++ b/extra/moon-eclipse/ghostty-flow-yellow.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#db7079
+palette = 9=#db7079
+# green
+palette = 2=#79db70
+palette = 10=#79db70
+# yellow
+palette = 3=#dbdb70
+palette = 11=#dbdb70
+# blue
+palette = 4=#70afdb
+palette = 12=#70afdb
+# purple
+palette = 5=#a670db
+palette = 13=#a670db
+# aqua
+palette = 6=#70dbc1
+palette = 14=#70dbc1
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #fbff00
+selection-background = #fbff00
+selection-foreground = #0d0d0d

--- a/extra/moon-penumbra/ghostty-flow-cyan.config
+++ b/extra/moon-penumbra/ghostty-flow-cyan.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #00e1ff
+selection-background = #00e1ff
+selection-foreground = #0d0d0d

--- a/extra/moon-penumbra/ghostty-flow-green.config
+++ b/extra/moon-penumbra/ghostty-flow-green.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #15ff00
+selection-background = #15ff00
+selection-foreground = #0d0d0d

--- a/extra/moon-penumbra/ghostty-flow-orange.config
+++ b/extra/moon-penumbra/ghostty-flow-orange.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #ff6a00
+selection-background = #ff6a00
+selection-foreground = #0d0d0d

--- a/extra/moon-penumbra/ghostty-flow-pink.config
+++ b/extra/moon-penumbra/ghostty-flow-pink.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #ff007b
+selection-background = #ff007b
+selection-foreground = #0d0d0d

--- a/extra/moon-penumbra/ghostty-flow-yellow.config
+++ b/extra/moon-penumbra/ghostty-flow-yellow.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #fbff00
+selection-background = #fbff00
+selection-foreground = #0d0d0d

--- a/extra/moon-umbra/ghostty-flow-cyan.config
+++ b/extra/moon-umbra/ghostty-flow-cyan.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #00e1ff
+selection-background = #00e1ff
+selection-foreground = #0d0d0d

--- a/extra/moon-umbra/ghostty-flow-green.config
+++ b/extra/moon-umbra/ghostty-flow-green.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #15ff00
+selection-background = #15ff00
+selection-foreground = #0d0d0d

--- a/extra/moon-umbra/ghostty-flow-orange.config
+++ b/extra/moon-umbra/ghostty-flow-orange.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #ff6a00
+selection-background = #ff6a00
+selection-foreground = #0d0d0d

--- a/extra/moon-umbra/ghostty-flow-pink.config
+++ b/extra/moon-umbra/ghostty-flow-pink.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #ff007b
+selection-background = #ff007b
+selection-foreground = #0d0d0d

--- a/extra/moon-umbra/ghostty-flow-yellow.config
+++ b/extra/moon-umbra/ghostty-flow-yellow.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #1f282e
+foreground = #d1dbe0
+# black
+palette = 0=#0d0d0d
+palette = 8=#0d0d0d
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#f2f2f2
+palette = 15=#f2f2f2
+
+cursor-color = #fbff00
+selection-background = #fbff00
+selection-foreground = #0d0d0d

--- a/extra/sun-eclipse/ghostty-flow-cyan.config
+++ b/extra/sun-eclipse/ghostty-flow-cyan.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#ba5e66
+palette = 9=#ba5e66
+# green
+palette = 2=#66ba5e
+palette = 10=#66ba5e
+# yellow
+palette = 3=#baba5e
+palette = 11=#baba5e
+# blue
+palette = 4=#5e94ba
+palette = 12=#5e94ba
+# purple
+palette = 5=#8c5eba
+palette = 13=#8c5eba
+# aqua
+palette = 6=#5ebaa3
+palette = 14=#5ebaa3
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #00e1ff
+selection-background = #00e1ff
+selection-foreground = #f2f2f2

--- a/extra/sun-eclipse/ghostty-flow-green.config
+++ b/extra/sun-eclipse/ghostty-flow-green.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#ba5e66
+palette = 9=#ba5e66
+# green
+palette = 2=#66ba5e
+palette = 10=#66ba5e
+# yellow
+palette = 3=#baba5e
+palette = 11=#baba5e
+# blue
+palette = 4=#5e94ba
+palette = 12=#5e94ba
+# purple
+palette = 5=#8c5eba
+palette = 13=#8c5eba
+# aqua
+palette = 6=#5ebaa3
+palette = 14=#5ebaa3
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #15ff00
+selection-background = #15ff00
+selection-foreground = #f2f2f2

--- a/extra/sun-eclipse/ghostty-flow-orange.config
+++ b/extra/sun-eclipse/ghostty-flow-orange.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#ba5e66
+palette = 9=#ba5e66
+# green
+palette = 2=#66ba5e
+palette = 10=#66ba5e
+# yellow
+palette = 3=#baba5e
+palette = 11=#baba5e
+# blue
+palette = 4=#5e94ba
+palette = 12=#5e94ba
+# purple
+palette = 5=#8c5eba
+palette = 13=#8c5eba
+# aqua
+palette = 6=#5ebaa3
+palette = 14=#5ebaa3
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #ff6a00
+selection-background = #ff6a00
+selection-foreground = #f2f2f2

--- a/extra/sun-eclipse/ghostty-flow-pink.config
+++ b/extra/sun-eclipse/ghostty-flow-pink.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#ba5e66
+palette = 9=#ba5e66
+# green
+palette = 2=#66ba5e
+palette = 10=#66ba5e
+# yellow
+palette = 3=#baba5e
+palette = 11=#baba5e
+# blue
+palette = 4=#5e94ba
+palette = 12=#5e94ba
+# purple
+palette = 5=#8c5eba
+palette = 13=#8c5eba
+# aqua
+palette = 6=#5ebaa3
+palette = 14=#5ebaa3
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #ff007b
+selection-background = #ff007b
+selection-foreground = #f2f2f2

--- a/extra/sun-eclipse/ghostty-flow-yellow.config
+++ b/extra/sun-eclipse/ghostty-flow-yellow.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#ba5e66
+palette = 9=#ba5e66
+# green
+palette = 2=#66ba5e
+palette = 10=#66ba5e
+# yellow
+palette = 3=#baba5e
+palette = 11=#baba5e
+# blue
+palette = 4=#5e94ba
+palette = 12=#5e94ba
+# purple
+palette = 5=#8c5eba
+palette = 13=#8c5eba
+# aqua
+palette = 6=#5ebaa3
+palette = 14=#5ebaa3
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #fbff00
+selection-background = #fbff00
+selection-foreground = #f2f2f2

--- a/extra/sun-penumbra/ghostty-flow-cyan.config
+++ b/extra/sun-penumbra/ghostty-flow-cyan.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #00e1ff
+selection-background = #00e1ff
+selection-foreground = #f2f2f2

--- a/extra/sun-penumbra/ghostty-flow-green.config
+++ b/extra/sun-penumbra/ghostty-flow-green.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #15ff00
+selection-background = #15ff00
+selection-foreground = #f2f2f2

--- a/extra/sun-penumbra/ghostty-flow-orange.config
+++ b/extra/sun-penumbra/ghostty-flow-orange.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #ff6a00
+selection-background = #ff6a00
+selection-foreground = #f2f2f2

--- a/extra/sun-penumbra/ghostty-flow-pink.config
+++ b/extra/sun-penumbra/ghostty-flow-pink.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #ff007b
+selection-background = #ff007b
+selection-foreground = #f2f2f2

--- a/extra/sun-penumbra/ghostty-flow-yellow.config
+++ b/extra/sun-penumbra/ghostty-flow-yellow.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#c98288
+palette = 9=#c98288
+# green
+palette = 2=#88c982
+palette = 10=#88c982
+# yellow
+palette = 3=#c9c982
+palette = 11=#c9c982
+# blue
+palette = 4=#82acc9
+palette = 12=#82acc9
+# purple
+palette = 5=#a682c9
+palette = 13=#a682c9
+# aqua
+palette = 6=#82c9b8
+palette = 14=#82c9b8
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #fbff00
+selection-background = #fbff00
+selection-foreground = #f2f2f2

--- a/extra/sun-umbra/ghostty-flow-cyan.config
+++ b/extra/sun-umbra/ghostty-flow-cyan.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #00e1ff
+selection-background = #00e1ff
+selection-foreground = #f2f2f2

--- a/extra/sun-umbra/ghostty-flow-green.config
+++ b/extra/sun-umbra/ghostty-flow-green.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #15ff00
+selection-background = #15ff00
+selection-foreground = #f2f2f2

--- a/extra/sun-umbra/ghostty-flow-orange.config
+++ b/extra/sun-umbra/ghostty-flow-orange.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #ff6a00
+selection-background = #ff6a00
+selection-foreground = #f2f2f2

--- a/extra/sun-umbra/ghostty-flow-pink.config
+++ b/extra/sun-umbra/ghostty-flow-pink.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #ff007b
+selection-background = #ff007b
+selection-foreground = #f2f2f2

--- a/extra/sun-umbra/ghostty-flow-yellow.config
+++ b/extra/sun-umbra/ghostty-flow-yellow.config
@@ -1,0 +1,33 @@
+# Flow colorscheme | Ghostty
+# https://github.com/0xstepit/flow.nvim
+
+background = #d1dbe0
+foreground = #3d505c
+# black
+palette = 0=#f2f2f2
+palette = 8=#f2f2f2
+# red
+palette = 1=#862d34
+palette = 9=#862d34
+# green
+palette = 2=#34862d
+palette = 10=#34862d
+# yellow
+palette = 3=#86862d
+palette = 11=#86862d
+# blue
+palette = 4=#2d6186
+palette = 12=#2d6186
+# purple
+palette = 5=#592d86
+palette = 13=#592d86
+# aqua
+palette = 6=#2d8670
+palette = 14=#2d8670
+# white
+palette = 7=#0d0d0d
+palette = 15=#0d0d0d
+
+cursor-color = #fbff00
+selection-background = #fbff00
+selection-foreground = #f2f2f2

--- a/lua/flow/config.lua
+++ b/lua/flow/config.lua
@@ -17,6 +17,10 @@ M.defaults = {
     mode = "default",
     ---@alias Fluo "pink" | "cyan" | "yellow" | "orange" | "green"
     fluo = "pink",
+    custom = {
+      saturation = "", -- Custom sturation value (0-360)
+      light = "", -- Custom lightness value (0-100)
+    },
   },
   ui = {
     ---@alias Borders "theme" | "inverse" | "fluo" | "none"
@@ -35,6 +39,10 @@ M.valid_options = {
   modes = { "default", "dark", "light" },
   borders = { "theme", "inverse", "fluo", "none" },
   contrast = { "default", "high" },
+  custom_ranges = {
+    saturation = { min = 0, max = 100 },
+    light = { min = 0, max = 100 },
+  },
 }
 
 --- Validate configuration options
@@ -59,6 +67,42 @@ local function validate_options(opts)
     if opts.colors.mode and not vim.tbl_contains(M.valid_options.modes, opts.colors.mode) then
       return false, string.format("Invalid mode: %s", opts.colors.mode)
     end
+
+    -- Validate custom color values for hue and light
+    if opts.colors.custom then
+      if opts.colors.custom.saturation and opts.colors.custom.saturation ~= "" then
+        local s = tonumber(opts.colors.custom.saturation)
+        if
+          not s
+          or s < M.valid_options.custom_ranges.saturation.min
+          or s > M.valid_options.custom_ranges.saturation.max
+        then
+          return false,
+            string.format(
+              "Invalid saturation value: %s (must be between %d and %d)",
+              opts.colors.custom.saturation,
+              M.valid_options.custom_ranges.saturation.min,
+              M.valid_options.custom_ranges.saturation.max
+            )
+        end
+      end
+      if opts.colors.custom.light and opts.colors.custom.light ~= "" then
+        local l = tonumber(opts.colors.custom.light)
+        if
+          not l
+          or l < M.valid_options.custom_ranges.light.min
+          or l > M.valid_options.custom_ranges.light.max
+        then
+          return false,
+            string.format(
+              "Invalid light value: %s (must be between %d and %d)",
+              opts.colors.custom.light,
+              M.valid_options.custom_ranges.light.min,
+              M.valid_options.custom_ranges.light.max
+            )
+        end
+      end
+    end
   end
 
   -- Validate ui options
@@ -67,6 +111,7 @@ local function validate_options(opts)
       return false, string.format("Invalid border: %s", opts.ui.borders)
     end
   end
+
   return true
 end
 

--- a/lua/flow/config.lua
+++ b/lua/flow/config.lua
@@ -17,8 +17,12 @@ M.defaults = {
     mode = "default",
     ---@alias Fluo "pink" | "cyan" | "yellow" | "orange" | "green"
     fluo = "pink",
+    ---@alias CustomSaturation string A number between 0-100 as string or empty string
+    ---@alias CustomLight string A number between 0-100 as string or empty string
     custom = {
-      saturation = "", -- Custom sturation value (0-360)
+      ---@type CustomSaturation
+      saturation = "", -- Custom saturation value (0-100)
+      ---@type CustomLight
       light = "", -- Custom lightness value (0-100)
     },
   },

--- a/lua/flow/extra/config.lua
+++ b/lua/flow/extra/config.lua
@@ -13,6 +13,7 @@ function M.get_dark_themes(fluo_color)
       colors = {
         mode = "default",
         fluo = fluo_color,
+        custom = { saturation = "", light = "" },
       },
       ui = {
         borders = "none",
@@ -29,6 +30,7 @@ function M.get_dark_themes(fluo_color)
       colors = {
         mode = "light",
         fluo = fluo_color,
+        custom = { saturation = "", light = "" },
       },
       ui = {
         borders = "none",
@@ -45,6 +47,7 @@ function M.get_dark_themes(fluo_color)
       colors = {
         mode = "dark",
         fluo = fluo_color,
+        custom = { saturation = "", light = "" },
       },
       ui = {
         borders = "none",
@@ -70,6 +73,7 @@ function M.get_light_themes(fluo_color)
       colors = {
         mode = "default",
         fluo = fluo_color,
+        custom = { saturation = "", light = "" },
       },
       ui = {
         borders = "none",
@@ -86,6 +90,7 @@ function M.get_light_themes(fluo_color)
       colors = {
         mode = "light",
         fluo = fluo_color,
+        custom = { saturation = "", light = "" },
       },
       ui = {
         borders = "none",
@@ -102,6 +107,7 @@ function M.get_light_themes(fluo_color)
       colors = {
         mode = "dark",
         fluo = fluo_color,
+        custom = { saturation = "", light = "" },
       },
       ui = {
         borders = "none",

--- a/lua/flow/extra/template/ghostty.lua
+++ b/lua/flow/extra/template/ghostty.lua
@@ -1,6 +1,4 @@
-package.path = package.path .. ";../?.lua;../flow/?.lua"
-
-local util = require("util")
+local util = require("flow.util")
 
 local M = {}
 

--- a/lua/flow/palette.lua
+++ b/lua/flow/palette.lua
@@ -19,6 +19,18 @@ function M.get(o)
     very_light = { S = 50, L = 85 },
   }
 
+  if o.colors.custom.light ~= "" then
+    ---@diagnostic disable-next-line: assign-type-mismatch
+    --- Options are validated here
+    shade[o.colors.mode].L = tonumber(o.colors.custom.light)
+  end
+
+  if o.colors.custom.saturation ~= "" then
+    ---@diagnostic disable-next-line: assign-type-mismatch
+    --- Options are validated here
+    shade[o.colors.mode].S = tonumber(o.colors.custom.saturation)
+  end
+
   local hue = {
     red = 355,
     purple = 270,


### PR DESCRIPTION
Add a new optional configuration parameter to allow user to specify custom Saturation and/or Light:

```lua
opts = {
    ...
    colors = {
        ...
        custom = {
          saturation = "80",
          light = "75",
        },
    },
},
```

The above example defines the S and L values of the HSL representation to have the V1.0.0 `bright` colors.