### PR TITLE
feat: Add support for flash.nvim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,17 @@ Below the list of supported plugins divided by category:
 
 - **Debug**: [nvim-dap](https://github.com/mfussenegger/nvim-dap).
 
-- **Plugins & Utils**: [lazy](https://github.com/folke/lazy.nvim),
-  [mason](https://github.com/williamboman/mason.nvim)
-
 - **Coding**: [telescope](https://github.com/nvim-telescope/telescope.nvim),
   [treesitter](https://github.com/nvim-treesitter/nvim-treesitter),
   [ibl](https://github.com/lukas-reineke/indent-blankline.nvim),
   [oil](https://github.com/stevearc/oil.nvim)
+  [flash](https://github.com/folke/flash.nvim)
 
 - **AI**: [avante](https://github.com/yetone/avante.nvim)
 
-- **Utils**: [trouble](https://github.com/folke/trouble.nvim),
+- **Utils**: [lazy](https://github.com/folke/lazy.nvim),
+  [mason](https://github.com/williamboman/mason.nvim)
+  [trouble](https://github.com/folke/trouble.nvim),
   [todo-comments](https://github.com/folke/todo-comments.nvim),
   [which-key](https://github.com/folke/which-key.nvim),
   [render-markdwon](https://github.com/MeanderingProgrammer/render-markdown.nvim),

--- a/lua/flow/highlights/base.lua
+++ b/lua/flow/highlights/base.lua
@@ -58,7 +58,7 @@ function M.get(c, o)
 
     -- Search and substitution
     IncSearch = { bg = (not is_dark and c.Fluo.dark) or c.Fluo.light, fg = c.bg_visual }, -- Last search pattern highlighting (see 'hlsearch').
-    Search = { link = "IncSearch" }, -- Used for 'incsearch' highlighting.
+    Search = { bg = c.grey[5], fg = c.bg_visual }, -- Used for 'incsearch' highlighting.
     CurSearch = { link = "IncSearch" }, -- Used for highlighting a search pattern under the cursor (see 'hlsearch').
     Substitute = { link = "IncSearch" }, -- |:substitute| replacement text highlighting.
     Visual = { bg = c.fg_visual, fg = c.bg_visual }, -- Visual mode selection.

--- a/lua/flow/highlights/flash.lua
+++ b/lua/flow/highlights/flash.lua
@@ -3,7 +3,7 @@ local M = {}
 -- Defines the highlight group colors for the flash.nvim plugins.
 --- @param c table: The available colors.
 --- @param o FlowConfig: The available options.
---- @return table: Diagnostic highlights.
+--- @return table: Plugin highlights.
 function M.get(c, o)
   local is_dark = o.theme.style == "dark"
 

--- a/lua/flow/highlights/flash.lua
+++ b/lua/flow/highlights/flash.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+-- Defines the highlight group colors for the flash.nvim plugins.
+--- @param c table: The available colors.
+--- @param o FlowConfig: The available options.
+--- @return table: Diagnostic highlights.
+function M.get(c, o)
+  local is_dark = o.theme.style == "dark"
+
+  local theme = {
+    FlashBackdrop = { fg = c.comment },
+    FlashLabel = { bg = c.fluo, fg = (not is_dark and c.grey[2]) or c.grey[7] },
+  }
+
+  return theme
+end
+
+return M

--- a/lua/flow/theme.lua
+++ b/lua/flow/theme.lua
@@ -12,6 +12,7 @@ M.active_highlights = {
   "completion",
   "dap",
   "diagnostic",
+  "flash",
   "git",
   "ibl",
   "lazy",


### PR DESCRIPTION
Add highlight groups for `flash.nvim` plugin:

<img width="1780" alt="Screenshot 2025-01-03 at 18 17 52" src="https://github.com/user-attachments/assets/f1df307a-b27a-4dea-a922-93d89715d70f" />

Closes #24 
