### PR TITLE
feat: Add configurable special comments

### DIFF
--- a/lua/flow/config.lua
+++ b/lua/flow/config.lua
@@ -31,6 +31,8 @@ M.defaults = {
     borders = "inverse",
     ---@boolean
     aggressive_spell = false,
+    ---@boolean
+    aggressive_special_comment = false,
   },
 }
 

--- a/lua/flow/highlights/mini-hipatterns.lua
+++ b/lua/flow/highlights/mini-hipatterns.lua
@@ -1,15 +1,13 @@
 local M = {}
 
---- @param c table: The available colors.
 --- @return table: Mini hi plugin highlights.
-function M.get(c, _)
+function M.get(_, _)
   local theme = {
     MiniHipatternsTodo = { link = "Todo" },
     MiniHipatternsFixme = { link = "Fixme" },
     MiniHipatternsNote = { link = "Note" },
     MiniHipatternsHack = { link = "Hack" },
-    MiniHipatternsWarn = { link = "Warn" },
-    MiniHipatternsContract = { fg = c.fluo, bg = c.comment },
+    MiniHipatternsContract = { link = "Fixme" },
   }
   return theme
 end

--- a/lua/flow/highlights/syntax.lua
+++ b/lua/flow/highlights/syntax.lua
@@ -1,8 +1,9 @@
 local M = {}
 
 --- @param c table: The available colors.
+--- @param o FlowConfig: The available options.
 --- @return table: Syntax highlights.
-function M.get(c, _)
+function M.get(c, o)
   local theme = {
 
     Boolean = { link = "Constant" }, -- A boolean constant: TRUE, false.
@@ -49,6 +50,19 @@ function M.get(c, _)
     Hack = { fg = c.hack, bg = c.comment },
     Warn = { fg = c.warning, bg = c.comment }, -- Anything that needs extra attention; mostly the keywords TODO FIXME and XXX.
   }
+
+  -- Special comments
+  if o.ui.aggressive_special_comment then
+    theme.Todo = { bg = c.todo, fg = c.comment }
+    theme.Fixme = { bg = c.fixme, fg = c.comment }
+    theme.Note = { bg = c.note, fg = c.comment }
+    theme.Hack = { bg = c.hack, fg = c.comment }
+  else
+    theme.Todo = { fg = c.todo, bg = c.comment }
+    theme.Fixme = { fg = c.fixme, bg = c.comment }
+    theme.Note = { fg = c.note, bg = c.comment }
+    theme.Hack = { fg = c.hack, bg = c.comment }
+  end
 
   return theme
 end


### PR DESCRIPTION
This PR add the option to customize how special comments are displayed via config:

```lua
  ...
  ui = {
   ...
    ---@boolean
    aggressive_special_comment = false, -- false/true
  },
  ...
```

When the flag is set to `false`:

<img width="425" alt="Screenshot 2025-01-15 at 11 33 39" src="https://github.com/user-attachments/assets/bf75bb48-03e9-4b59-b89f-3d0c0910808e" />

When it is set to `true`:

<img width="425" alt="Screenshot 2025-01-15 at 11 34 20" src="https://github.com/user-attachments/assets/a9e85dde-3f1a-477b-8b47-ead1abd6e3bb" />